### PR TITLE
Fix arrow keys working inconsistently

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -107,7 +107,7 @@ document.onkeydown = e => {
     if (dev) console.log('key', key);
     switch (key) {
         case 32: // space
-            if (videoElement) e.preventDefault();
+            if (getVideoElement()) e.preventDefault();
             break;
         case 37: // <-
             skip(-10);

--- a/src/content.js
+++ b/src/content.js
@@ -2,11 +2,11 @@
 
 /**
  * restrict a number to a certain boundary
- * 
+ *
  * @param {number} num number you want to restrict
  * @param {number} min lowest int num can be
  * @param {number} max highest int num can be
- * 
+ *
  * @return {number} num restricted on {min...max}
  */
 clamp = (num, min, max) => {
@@ -23,8 +23,11 @@ const mediaUrlRegex = RegExp('^https://play.hbonow.com/(feature|episode|extra)/.
 
 // elements
 let barElement   = null; // grey bars element
-let videoElement = null; // video element
 let mediaElement = null; // media toolbar element
+
+const getVideoElement = () => {
+    return document.querySelector('video.default');
+}
 
 // search
 let searching      = true;
@@ -52,7 +55,6 @@ resetSearch = () => {
     clearInterval(searchInterval);
     searching = true;
     barElement = null;
-    videoElement = null;
     mediaElement = null;
 }
 
@@ -77,15 +79,6 @@ restartSearchInterval = () => {
                 return el.style['backgroundColor'] === 'rgb(15, 15, 15)';
             });
             toggleBars(true);
-        }
-
-        // VIDEO ELEMENT
-        if (!videoElement) {
-            const videoElements = document.getElementsByTagName('video');
-            if (videoElements.length === 1) videoElement = videoElements[0];
-            else if (videoElements.length > 1) {
-                console.error('Error: More than one video element in current DOM.');
-            }
         }
 
         // MEDIA TOOLBAR ELEMENT
@@ -140,6 +133,7 @@ document.onkeydown = e => {
 }
 
 skip = (amt) => {
+    const videoElement = getVideoElement();
     if (videoElement) {
         const newTime = videoElement.currentTime + amt;
         videoElement.currentTime = clamp(newTime, 0, videoElement.duration);
@@ -147,6 +141,7 @@ skip = (amt) => {
 }
 
 alterVolume = (e, amt) => {
+    const videoElement = getVideoElement();
     // changing this doesn't reflect what's displayed on screen!!
     if (videoElement) {
         e.preventDefault();


### PR DESCRIPTION
Arrow keys often break on page load. This often happens after autoplay, but I'm also seeing it a lot of time when loading up a show for the first time.

The cause seems to be that the page will sometimes replace the video element during inital page load, so the video element that the extension is trying to reference is no longer attached to the document. This causes the extension to simply throw an error.

My solution here is just to query the document for the element on demand. Querying by class name is an extremely fast operation, so there isn't much reason to cache the element. This way, all that matters is what video element matches at the exact moment that you press the arrow key.

I've done some manual testing, and haven't reproduced the issue after applying this fix.